### PR TITLE
Type your signature feature with a clean navbar added

### DIFF
--- a/type.css
+++ b/type.css
@@ -110,7 +110,7 @@ button:hover {
     width: 80%;
     max-width: 500px;
     border: 2px solid #fff;
-    color: #fff;
+    color: #000000;
     background-color: transparent;
 }
 

--- a/type.css
+++ b/type.css
@@ -1,0 +1,235 @@
+/* General Reset */
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+    font-family: 'Roboto', sans-serif;
+}
+
+/* Body Styling */
+body {
+    background: url('https://wallpapers.com/images/hd/minimalist-vintage-1920-x-1080-wallpaper-h18al5zfcc6wozfv.jpg') center/cover no-repeat;
+    color: #fff;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+    text-align: center;
+    padding-top: 70px;
+}
+
+/* Button Styling */
+button {
+    padding: 10px 20px;
+    border-radius: 5px;
+    font-size: 16px;
+    cursor: pointer;
+    transition: background-color 0.3s ease, transform 0.2s ease;
+}
+
+button:hover {
+    transform: scale(1.05);
+    background-color: #f39c12 ;
+}
+/* Navbar Styling */
+.navbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 15px 50px;
+    background: rgba(0, 0, 0, 0.8);
+    position: fixed;
+    width: 100%;
+    top: 0;
+    z-index: 1000;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+}
+
+.logo img {
+    height: 50px;
+}
+
+/* Navigation Links Styling */
+.nav-links {
+    display: flex;
+    list-style: none;
+    gap: 25px;
+}
+
+.nav-links a {
+    color: white;
+    font-size: 18px;
+    font-weight: bold;
+    text-decoration: none;
+    transition: color 0.3s ease, text-decoration 0.3s ease;
+}
+
+/* Underline Effect on Hover */
+.nav-links a:hover {
+    color: #ecf0f1;
+    text-decoration: underline;
+}
+
+/* Login Button Styling */
+.navbar .login-btn {
+    background-color: #f39c12;
+    color: white;
+    border: none;
+    padding: 10px 20px;
+    font-size: 18px;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: background-color 0.3s ease, transform 0.2s ease, box-shadow 0.3s ease;
+}
+
+.navbar .login-btn:hover {
+    background-color: #e67e22;
+    transform: scale(1.1);
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2); /* Added shadow effect */
+}
+
+/* Main Content */
+.container {
+    margin-top: 120px; /* Adjusted for header space */
+    text-align: center;
+    width: 100%;
+}
+
+.container h1 {
+    font-size: 2.5em;
+    margin-bottom: 20px;
+    color: black;
+}
+
+.container input {
+    font-size: 1.2em;
+    padding: 10px;
+    margin-bottom: 20px;
+    border-radius: 5px;
+    width: 80%;
+    max-width: 500px;
+    border: 2px solid #fff;
+    color: #fff;
+    background-color: transparent;
+}
+
+.container button {
+    padding: 10px 20px;
+    border-radius: 5px;
+    font-size: 16px;
+    cursor: pointer;
+    transition: background-color 0.3s ease, transform 0.2s ease;
+    background-color: #f39c12;
+    color: white;
+    border: none;
+}
+
+.container button:hover {
+    transform: scale(1.05);
+    background-color: #e67e22;
+}
+
+/* Footer Styling */
+.footer {
+    display: flex;
+    justify-content: space-between;
+    background: rgba(0, 0, 0, 0.9);
+    position: fixed;
+    bottom: 0;
+    width: 100%;
+    color: #fff;
+    font-size: 14px;
+    padding: 10px 20px;
+}
+
+.footer .social-icons a img {
+    width: 20px;
+    height: 20px;
+    transition: transform 0.3s ease;
+}
+
+.footer .social-icons a img:hover {
+    transform: scale(1.2);
+}
+
+.footer .name p {
+    font-size: 14px;
+}
+
+.alink {
+    color: #fff;
+}
+
+.alink:hover {
+    text-decoration: underline;
+}
+
+/* Additional Content Styling */
+.container {
+    margin-top: 50px;
+}
+
+#fontStylesContainer {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr); /* Three containers per row */
+    gap: 20px;
+    justify-items: center;
+    margin-top: 20px;
+}
+
+.fontDesign {
+    padding: 15px;
+    border: 1px solid #ccc;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+    width: 350px;
+    height: 150px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: space-between;
+    border-radius: 10px;
+}
+
+.fontDesign:hover {
+    transform: scale(1.05);
+    box-shadow: 0 0 15px rgba(0, 0, 0, 0.3);
+}
+
+
+#textInput {
+    padding: 10px;
+    margin-bottom: 20px;
+    font-size: 16px;
+    width: 300px;
+}
+
+button {
+    padding: 10px 20px;
+    background-color: #f39c12;
+    color: white;
+    border: none;
+    cursor: pointer;
+    transition: background-color 0.3s ease, transform 0.2s ease;
+
+}
+
+button:hover {
+    background-color: #e67e22;
+    transform: scale(1.05);
+}
+
+.downloadBtn {
+    position: absolute;
+    bottom: 10px;
+    left: 50%;
+    transform: scale(1.05);
+    padding: 10px 15px;
+    border: none;
+    border-radius: 5px;
+    background: #f39c12;
+    color: rgb(255, 255, 255);
+    cursor: pointer;
+    transition: background 0.3s ease, transform 0.2s ease;
+}
+

--- a/type.html
+++ b/type.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Font Style Generator</title>
+    <link rel="stylesheet" href="type.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+        href="https://fonts.googleapis.com/css2?family=Alex+Brush&family=Amita:wght@400;700&family=Arizonia&family=Lavishly+Yours&family=Mrs+Saint+Delafield&family=Rouge+Script&display=swap"
+        rel="stylesheet">
+</head>
+
+<body>
+    <!-- Navbar -->
+    <nav class="navbar">
+        <div class="logo">Signature App</div>
+        <ul class="nav-links">
+            <li><a href="#home">Home</a></li>
+            <li><a href="#pricing">Pricing</a></li>
+            <li><a href="#about">About Us</a></li>
+            <li><a href="#contact">Contact</a></li>
+        </ul>
+        <button class="login-button" onclick="window.location.href='login.html'">Login</button>
+    </nav>
+
+    <!-- Main Content -->
+    <div class="container">
+        <h1>Type Your Signature</h1>
+        <input type="text" id="textInput" placeholder="Enter text to style">
+        <button id="generateBtn">Generate</button>
+
+        <div id="fontStylesContainer"></div>
+    </div>
+
+    <!-- Footer -->
+    <footer class="footer">
+        <div class="name">
+            <p><i>Made By</i> <a class="alink" href="https://github.com/anchalchaturvedi08"><i>Anchal Chaturvedi</i></a></p>
+        </div>
+        <p>&copy; 2025 <i>Signature App</i> | All rights reserved.</p>
+        <div class="connect">
+            <p>Connect With Us:</p>
+            <div class="social-icons">
+                <a href="https://twitter.com" target="_blank">
+                    <img src="https://cdn-icons-png.flaticon.com/512/733/733579.png" alt="Twitter">
+                </a>
+                <a href="https://instagram.com" target="_blank">
+                    <img src="https://cdn-icons-png.flaticon.com/512/733/733558.png" alt="Instagram">
+                </a>
+                <a href="https://linkedin.com" target="_blank">
+                    <img src="https://cdn-icons-png.flaticon.com/512/733/733561.png" alt="LinkedIn">
+                </a>
+                <a href="https://github.com/anchalchaturvedi08" target="_blank">
+                    <img src="https://cdn-icons-png.flaticon.com/512/25/25231.png" alt="GitHub">
+                </a>
+            </div>
+        </div>
+    </footer>
+
+
+    <script src="type.js"></script>
+</body>
+
+</html>

--- a/type.js
+++ b/type.js
@@ -1,0 +1,46 @@
+document.getElementById('generateBtn').addEventListener('click', generateFonts);
+
+const fonts = [
+    { name: 'Mrs Saint Delafield', class: 'mrs-saint-delafield-regular', family: '"Mrs Saint Delafield", serif' },
+    { name: 'Lavishly Yours', class: 'lavishly-yours-regular', family: '"Lavishly Yours", serif' },
+    { name: 'Arizonia', class: 'arizonia-regular', family: '"Arizonia", serif' },
+    { name: 'Rouge Script', class: 'rouge-script-regular', family: '"Rouge Script", serif' },
+    { name: 'Alex Brush', class: 'alex-brush-regular', family: '"Alex Brush", serif' },
+    { name: 'Amita', class: 'amita-regular', family: '"Amita", serif' },
+];
+
+function generateFonts() {
+    const textInput = document.getElementById('textInput').value;
+    const container = document.getElementById('fontStylesContainer');
+    container.innerHTML = '';  // Clear previous designs
+
+    fonts.forEach((font, index) => {
+        const fontDesignDiv = document.createElement('div');
+        fontDesignDiv.classList.add('fontDesign');
+        
+        const canvas = document.createElement('canvas');
+        canvas.width = 300;
+        canvas.height = 100;
+        const ctx = canvas.getContext('2d');
+        
+        // Apply the correct font-family and size to the canvas
+        ctx.font = `30px ${font.family}`;
+        ctx.fillText(textInput, 10, 50);
+
+        fontDesignDiv.appendChild(canvas);
+
+        // Download button
+        const downloadBtn = document.createElement('button');
+        downloadBtn.classList.add('downloadBtn');
+        downloadBtn.textContent = 'Download';
+        downloadBtn.addEventListener('click', function () {
+            const link = document.createElement('a');
+            link.download = `fontDesign-${index}.png`;
+            link.href = canvas.toDataURL();
+            link.click();
+        });
+        
+        fontDesignDiv.appendChild(downloadBtn);
+        container.appendChild(fontDesignDiv);
+    });
+}


### PR DESCRIPTION
I have a added a new typing feature for Signature. Once u type and hit generate 6 signature styles will show with the download button. You can easily download your signature in png format. I try to keep the page align with the Ui. we can include more signature style option but because of the background image, I am bounded to 6 styles. I have attached the images after changes. Give me your opinion. Then we can move to our next page.

But could you kindly assign more specific labels(Beginner/Intermediate/Advanced) to the contributions. so it can be accurately categorized and counted toward my SWOC25 contributions?
thank you!!
![type_1](https://github.com/user-attachments/assets/e2a829db-7b55-4cc8-8fbd-26bf857b0465)
![type_2](https://github.com/user-attachments/assets/2681d736-7b9d-4c9d-bf82-ce27cd4f3cac)
![type_3](https://github.com/user-attachments/assets/aaf54016-a209-49d7-812f-5b38eadd4dd0)
![type_4](https://github.com/user-attachments/assets/72801ed8-92f6-4c71-af97-e17a92a2e590)
